### PR TITLE
Update gitignore: fix exclusion for bower_components

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -59,7 +59,7 @@ test/
 *.sublime-workspace
 *.sublime-projectcompletions
 
-app/_bower_components
+src/_bower_components
 
 # Output folders
 serve


### PR DESCRIPTION
The gitignore exclusion was pointing to app/_bower_components which doesn't exist in the generated project and doesn't match .bowerrc.